### PR TITLE
Ignore whitespace before upper case SQL keywords

### DIFF
--- a/syntaxes/highlight-string-code.json
+++ b/syntaxes/highlight-string-code.json
@@ -165,7 +165,7 @@
                     ]
                 },
                 {
-                    "begin": "(SELECT|INSERT|DELETE|UPDATE|DROP|ALTER|CREATE|SET|TRUNCATE|GRANT|REVOKE)\\s",
+                    "begin": "\\s*(SELECT|INSERT|DELETE|UPDATE|DROP|ALTER|CREATE|SET|TRUNCATE|GRANT|REVOKE)\\s",
                     "end": "(;)",
                     "beginCaptures": {
                         "1": {


### PR DESCRIPTION
Fixes #16

Not sure if this will interfere with anything, but unless you write a lot of strings with upper case SQL keywords that are **not** sql string, I think it should be fine?